### PR TITLE
使用系统设置的文件类型、文件读取方式优化、S3直传实现

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -1,0 +1,269 @@
+<?php
+if (!defined('__TYPECHO_ROOT_DIR__')) exit;
+
+/**
+ * S3 直传 Action 处理器
+ * 
+ * @package S3Upload
+ * @author OpenCode
+ * @version 1.0.0
+ */
+class S3Upload_Action extends \Typecho\Widget implements \Widget\ActionInterface
+{
+    /**
+     * 执行Action
+     */
+    public function action()
+    {
+        // 验证用户权限
+        $user = \Typecho\Widget::widget('Widget\User');
+        if (!$user->pass('contributor', true)) {
+            $this->response->setStatus(403);
+            $this->response->throwJson(['error' => '没有权限']);
+            return;
+        }
+        
+        $do = $this->request->get('do');
+        
+        switch ($do) {
+            case 'getUploadUrl':
+                $this->getUploadUrl();
+                break;
+            case 'confirmUpload':
+                $this->confirmUpload();
+                break;
+            case 'delete':
+                $this->deleteFile();
+                break;
+            default:
+                $this->response->setStatus(400);
+                $this->response->throwJson(['error' => '未知操作']);
+        }
+    }
+    
+    /**
+     * 获取预签名上传URL
+     */
+    private function getUploadUrl()
+    {
+        try {
+            // 验证安全令牌
+            $security = \Typecho\Widget::widget('Widget\Security');
+            $security->protect();
+            
+            // 获取请求数据
+            $input = file_get_contents('php://input');
+            $data = json_decode($input, true);
+            
+            if (empty($data['filename'])) {
+                throw new Exception('文件名不能为空');
+            }
+            
+            $filename = $data['filename'];
+            $contentType = $data['contentType'] ?? 'application/octet-stream';
+            $fileSize = $data['size'] ?? 0;
+            
+            // 验证文件类型
+            $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+            $options = \Typecho\Widget::widget('Widget\Options');
+            
+            if (!in_array($ext, $options->allowedAttachmentTypes)) {
+                throw new Exception('不支持的文件类型: ' . $ext);
+            }
+            
+            // 获取S3客户端
+            $s3Client = S3Upload_S3Client::getInstance();
+            
+            // 生成存储路径
+            $path = $s3Client->generateFullPath($filename);
+            
+            // 生成预签名URL
+            $presignedData = $s3Client->getPresignedUploadUrl($path, $contentType);
+            
+            S3Upload_Utils::log("生成预签名URL: " . print_r($presignedData, true), 'debug');
+            
+            $this->response->throwJson($presignedData);
+            
+        } catch (Exception $e) {
+            S3Upload_Utils::log("获取上传URL失败: " . $e->getMessage(), 'error');
+            $this->response->setStatus(500);
+            $this->response->throwJson(['error' => $e->getMessage()]);
+        }
+    }
+    
+    /**
+     * 确认上传完成，写入数据库
+     */
+    private function confirmUpload()
+    {
+        try {
+            // 验证安全令牌
+            $security = \Typecho\Widget::widget('Widget\Security');
+            $security->protect();
+            
+            // 获取请求数据
+            $input = file_get_contents('php://input');
+            $data = json_decode($input, true);
+            
+            if (empty($data['path']) || empty($data['name'])) {
+                throw new Exception('缺少必要参数');
+            }
+            
+            $path = $data['path'];
+            $name = $data['name'];
+            $size = $data['size'] ?? 0;
+            $contentType = $data['type'] ?? 'application/octet-stream';
+            $parentCid = !empty($data['cid']) ? intval($data['cid']) : null;
+            
+            // 获取文件扩展名
+            $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+            
+            // 获取S3客户端生成URL
+            $s3Client = S3Upload_S3Client::getInstance();
+            $url = $s3Client->getObjectUrl($path);
+            
+            // 判断是否为图片
+            $isImage = in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']);
+            
+            // 构建附件数据
+            $attachment = [
+                'name' => $name,
+                'path' => $path,
+                'size' => $size,
+                'type' => $ext,
+                'mime' => $contentType,
+                'isImage' => $isImage ? 1 : 0,
+                'url' => $url
+            ];
+            
+            // 写入数据库
+            $user = \Typecho\Widget::widget('Widget\User');
+            $db = \Typecho\Db::get();
+            
+            $struct = [
+                'title' => $name,
+                'slug' => $name,
+                'created' => time(),
+                'modified' => time(),
+                'type' => 'attachment',
+                'status' => 'publish',
+                'authorId' => $user->uid,
+                'text' => json_encode($attachment),
+                'allowComment' => 1,
+                'allowPing' => 0,
+                'allowFeed' => 1
+            ];
+            
+            if ($parentCid) {
+                // 验证父文章是否存在且有权限
+                $parent = $db->fetchRow($db->select()->from('table.contents')
+                    ->where('cid = ?', $parentCid)
+                    ->where('type = ?', 'post'));
+                    
+                if ($parent) {
+                    $struct['parent'] = $parentCid;
+                }
+            }
+            
+            $insertId = $db->query($db->insert('table.contents')->rows($struct));
+            
+            S3Upload_Utils::log("附件已写入数据库, cid: {$insertId}", 'debug');
+            
+            // 返回结果
+            $this->response->throwJson([
+                'success' => true,
+                'attachment' => [
+                    'cid' => $insertId,
+                    'title' => $name,
+                    'type' => $ext,
+                    'size' => $size,
+                    'bytes' => number_format(ceil($size / 1024)) . ' Kb',
+                    'isImage' => $isImage,
+                    'url' => $url,
+                    'permalink' => $url
+                ]
+            ]);
+            
+        } catch (Exception $e) {
+            S3Upload_Utils::log("确认上传失败: " . $e->getMessage(), 'error');
+            $this->response->setStatus(500);
+            $this->response->throwJson(['error' => $e->getMessage()]);
+        }
+    }
+    
+    /**
+     * 删除文件
+     */
+    private function deleteFile()
+    {
+        try {
+            // 验证安全令牌
+            $security = \Typecho\Widget::widget('Widget\Security');
+            $security->protect();
+            
+            // 获取cid参数
+            $cid = $this->request->get('cid');
+            if (empty($cid)) {
+                throw new Exception('缺少文件ID');
+            }
+            
+            $cid = intval($cid);
+            $user = \Typecho\Widget::widget('Widget\User');
+            $db = \Typecho\Db::get();
+            
+            // 查询附件信息
+            $attachment = $db->fetchRow($db->select()->from('table.contents')
+                ->where('cid = ?', $cid)
+                ->where('type = ?', 'attachment'));
+            
+            if (!$attachment) {
+                throw new Exception('附件不存在');
+            }
+            
+            // 检查权限：只有管理员或作者本人可以删除
+            if (!$user->pass('administrator', true) && $attachment['authorId'] != $user->uid) {
+                throw new Exception('没有权限删除此附件');
+            }
+            
+            // 解析附件数据获取S3路径
+            $attachmentData = json_decode($attachment['text'], true);
+            $s3Path = $attachmentData['path'] ?? '';
+            
+            S3Upload_Utils::log("准备删除附件, cid: {$cid}, 路径: {$s3Path}", 'debug');
+            S3Upload_Utils::log("附件数据: " . print_r($attachmentData, true), 'debug');
+            
+            $s3Deleted = false;
+            
+            // 从S3删除文件
+            if (!empty($s3Path)) {
+                $s3Client = S3Upload_S3Client::getInstance();
+                $s3Deleted = $s3Client->deleteObject($s3Path);
+                
+                if ($s3Deleted) {
+                    S3Upload_Utils::log("已从S3删除文件: {$s3Path}", 'debug');
+                } else {
+                    S3Upload_Utils::log("从S3删除文件失败: {$s3Path}", 'warning');
+                }
+            } else {
+                S3Upload_Utils::log("附件没有S3路径，跳过S3删除", 'warning');
+            }
+            
+            // 从数据库删除记录
+            $db->query($db->delete('table.contents')->where('cid = ?', $cid));
+            
+            S3Upload_Utils::log("附件数据库记录已删除, cid: {$cid}", 'debug');
+            
+            $this->response->throwJson([
+                'success' => true,
+                'message' => '删除成功',
+                's3Deleted' => $s3Deleted,
+                's3Path' => $s3Path
+            ]);
+            
+        } catch (Exception $e) {
+            S3Upload_Utils::log("删除文件失败: " . $e->getMessage(), 'error');
+            $this->response->setStatus(500);
+            $this->response->throwJson(['error' => $e->getMessage()]);
+        }
+    }
+}

--- a/FileHandler.php
+++ b/FileHandler.php
@@ -18,11 +18,14 @@ class S3Upload_FileHandler
                 return false;
             }
 
+            // 先获取 options 对象
+            $totalOptions = \Typecho\Widget::widget('Widget\Options');
+            
             $ext = self::getSafeName($file['name']);
 
-            // Typecho 1.3.0 文件类型检查
-            $allowedTypes = ['jpg', 'jpeg', 'gif', 'png', 'webp', 'bmp', 'mp4', 'avi', 'mov', 'wmv', 'flv', 'mp3', 'wav', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'zip', 'rar'];
-            if (!in_array(strtolower($ext), $allowedTypes)) {
+            // 使用从全局配置中获取的 allowedAttachmentTypes
+            // 这才是 Typecho 的标准做法！
+            if (!in_array(strtolower($ext), $totalOptions->allowedAttachmentTypes)) {
                 return false;
             }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -33,7 +33,11 @@ class S3Upload_Plugin implements PluginInterface
         \Typecho\Plugin::factory('Widget\Upload')->attachmentHandle = ['S3Upload_FileHandler', 'attachmentHandle'];
         \Typecho\Plugin::factory('Widget\Upload')->attachmentDataHandle = ['S3Upload_FileHandler', 'attachmentDataHandle'];
         
-
+        // 注册直传S3的前端脚本注入
+        \Typecho\Plugin::factory('admin/footer.php')->end = ['S3Upload_Plugin', 'injectDirectUploadScript'];
+        
+        // 添加自定义Action路由 (通过actionTable)
+        \Utils\Helper::addAction('s3upload', 'S3Upload_Action');
         
         return _t('插件已经激活，请设置 S3 配置信息');
     }
@@ -55,7 +59,335 @@ class S3Upload_Plugin implements PluginInterface
      */
     public static function deactivate()
     {
+        // 移除自定义Action
+        \Utils\Helper::removeAction('s3upload');
         return _t('插件已被禁用');
+    }
+
+    /**
+     * 注入直传S3的前端脚本
+     */
+    public static function injectDirectUploadScript()
+    {
+        $options = \Typecho\Widget::widget('Widget\Options');
+        $security = \Typecho\Widget::widget('Widget\Security');
+        
+        // 获取插件配置
+        $pluginOptions = $options->plugin('S3Upload');
+        
+        // 获取允许的文件类型
+        $allowedTypes = json_encode($options->allowedAttachmentTypes);
+        
+        // 获取PHP最大上传大小
+        $phpMaxFilesize = function_exists('ini_get') ? trim(ini_get('upload_max_filesize')) : '0';
+        if (preg_match("/^([0-9]+)([a-z]{1,2})?$/i", $phpMaxFilesize, $matches)) {
+            $size = intval($matches[1]);
+            $unit = $matches[2] ?? 'b';
+            $phpMaxFilesize = round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
+        }
+        
+        // 构建API URL - 使用 Common::url 确保正确格式
+        $apiUrl = \Typecho\Common::url('action/s3upload', $options->index);
+        
+        // 获取管理后台URL
+        $adminUrl = $options->adminUrl;
+        
+        echo <<<SCRIPT
+<script>
+$(document).ready(function () {
+    (function() {
+        // 只在有上传区域的页面执行
+        if (!document.querySelector('.upload-area')) return;
+        
+        const S3DirectUpload = {
+            apiUrl: '{$apiUrl}',
+            adminUrl: '{$adminUrl}',
+            allowedTypes: {$allowedTypes},
+            maxSize: {$phpMaxFilesize},
+            
+            // 从页面上传URL中获取安全令牌
+            getSecurityToken: function() {
+                const uploadArea = document.querySelector('.upload-area');
+                if (uploadArea) {
+                    const url = uploadArea.dataset.url || '';
+                    const match = url.match(/[?&]_=([a-f0-9]+)/);
+                    if (match) return match[1];
+                }
+                return '';
+            },
+            
+            // 获取预签名URL
+            async getPresignedUrl(filename, contentType, fileSize) {
+                const token = this.getSecurityToken();
+                const response = await fetch(this.apiUrl + '?do=getUploadUrl&_=' + token, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        filename: filename,
+                        contentType: contentType,
+                        size: fileSize
+                    }),
+                    credentials: 'same-origin'
+                });
+                
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    throw new Error(err.error || '获取上传URL失败');
+                }
+                
+                return response.json();
+            },
+            
+            // 直接上传到S3
+            async uploadToS3(presignedData, file) {
+                const response = await fetch(presignedData.uploadUrl, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': presignedData.contentType
+                    },
+                    body: file,
+                    mode: 'cors'
+                });
+                
+                if (!response.ok) {
+                    throw new Error('上传到S3失败: ' + response.status);
+                }
+                
+                return true;
+            },
+            
+            // 确认上传完成
+            async confirmUpload(presignedData, file, cid) {
+                const token = this.getSecurityToken();
+                const response = await fetch(this.apiUrl + '?do=confirmUpload&_=' + token, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        path: presignedData.path,
+                        name: file.name,
+                        size: file.size,
+                        type: presignedData.contentType,
+                        cid: cid || null
+                    }),
+                    credentials: 'same-origin'
+                });
+                
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    throw new Error(err.error || '确认上传失败');
+                }
+                
+                return response.json();
+            },
+            
+            // 完整上传流程
+            async upload(file, cid) {
+                // 1. 获取预签名URL
+                const presignedData = await this.getPresignedUrl(file.name, file.type || 'application/octet-stream', file.size);
+                
+                // 2. 直接上传到S3
+                await this.uploadToS3(presignedData, file);
+                
+                // 3. 确认上传，写入数据库
+                const result = await this.confirmUpload(presignedData, file, cid);
+                
+                return result;
+            },
+            
+            // 删除文件
+            async deleteFile(cid) {
+                const token = this.getSecurityToken();
+                const response = await fetch(this.apiUrl + '?do=delete&cid=' + cid + '&_=' + token, {
+                    method: 'POST',
+                    credentials: 'same-origin'
+                });
+                
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    throw new Error(err.error || '删除失败');
+                }
+                
+                return response.json();
+            }
+        };
+        
+        // 覆盖原有的Typecho.uploadFile方法
+        let uploadIndex = 0;
+        const uploadQueue = [];
+        
+        function processQueue() {
+            const item = uploadQueue.shift();
+            if (!item) return;
+            
+            const { file, cid } = item;
+            
+            S3DirectUpload.upload(file, cid)
+                .then(result => {
+                    if (result && result.attachment) {
+                        // 触发上传完成事件
+                        const li = document.getElementById(file.id);
+                        if (li) {
+                            li.classList.remove('loading');
+                            li.dataset.cid = result.attachment.cid;
+                            li.dataset.url = result.attachment.url;
+                            li.dataset.image = result.attachment.isImage;
+                            li.innerHTML = '<input type="hidden" name="attachment[]" value="' + result.attachment.cid + '" />'
+                                + '<a class="insert" target="_blank" href="###" title="点击插入文件">'
+                                + result.attachment.title + '</a><div class="info">' + result.attachment.bytes
+                                + ' <a class="file" target="_blank" href="' + S3DirectUpload.adminUrl + 'media.php?cid=' 
+                                + result.attachment.cid + '" title="编辑"><i class="i-edit"></i></a>'
+                                + ' <a class="delete" href="###" title="删除"><i class="i-delete"></i></a></div>';
+                            
+                            // 绑定事件
+                            attachS3Events(li);
+                            updateAttachmentNumber();
+                            
+                            if (typeof Typecho.uploadComplete === 'function') {
+                                Typecho.uploadComplete(result.attachment);
+                            }
+                        }
+                    }
+                    processQueue();
+                })
+                .catch(error => {
+                    console.error('S3直传失败:', error);
+                    const li = document.getElementById(file.id);
+                    if (li) {
+                        li.classList.remove('loading');
+                        li.innerHTML = file.name + ' 上传失败<br />' + error.message;
+                        li.style.backgroundColor = '#FBC2C4';
+                        setTimeout(() => li.remove(), 3000);
+                    }
+                    processQueue();
+                });
+        }
+        
+        function attachS3Events(el) {
+            const insertBtn = el.querySelector('.insert');
+            if (insertBtn) {
+                insertBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    const li = this.closest('li');
+                    Typecho.insertFileToEditor(this.textContent, li.dataset.url, li.dataset.image === 'true' || li.dataset.image === '1');
+                });
+            }
+            
+            const deleteBtn = el.querySelector('.delete');
+            if (deleteBtn) {
+                // 移除原有事件（如果有的话）
+                const newDeleteBtn = deleteBtn.cloneNode(true);
+                deleteBtn.parentNode.replaceChild(newDeleteBtn, deleteBtn);
+                
+                newDeleteBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const li = this.closest('li');
+                    const fileName = li.querySelector('.insert').textContent;
+                    if (confirm('确认要删除文件 ' + fileName + ' 吗?')) {
+                        const cid = li.dataset.cid;
+                        S3DirectUpload.deleteFile(cid)
+                            .then(() => {
+                                li.style.opacity = '0';
+                                li.style.transition = 'opacity 0.3s';
+                                setTimeout(() => {
+                                    li.remove();
+                                    updateAttachmentNumber();
+                                }, 300);
+                            })
+                            .catch(err => {
+                                console.error('删除失败:', err);
+                                alert('删除失败: ' + err.message);
+                            });
+                    }
+                });
+            }
+        }
+        
+        function updateAttachmentNumber() {
+            const btn = document.getElementById('tab-files-btn');
+            if (!btn) return;
+            
+            let balloon = btn.querySelector('.balloon');
+            const count = document.querySelectorAll('#file-list li .insert').length;
+            
+            if (count > 0) {
+                if (!balloon) {
+                    btn.innerHTML = btn.innerHTML.trim() + ' ';
+                    balloon = document.createElement('span');
+                    balloon.className = 'balloon';
+                    btn.appendChild(balloon);
+                }
+                balloon.textContent = count;
+            } else if (balloon) {
+                balloon.remove();
+            }
+        }
+        
+        // 替换上传方法
+        Typecho.uploadFile = function(file) {
+            file.id = 'upload-' + (uploadIndex++);
+            
+            // 检查文件大小
+            if (file.size > S3DirectUpload.maxSize) {
+                showUploadError('size', file);
+                return;
+            }
+            
+            // 检查文件类型
+            const match = file.name.match(/\\.([a-z0-9]+)\$/i);
+            if (!match || S3DirectUpload.allowedTypes.indexOf(match[1].toLowerCase()) < 0) {
+                showUploadError('type', file);
+                return;
+            }
+            
+            // 显示上传中状态
+            const fileList = document.getElementById('file-list');
+            const li = document.createElement('li');
+            li.id = file.id;
+            li.className = 'loading';
+            li.textContent = file.name;
+            fileList.appendChild(li);
+            
+            // 获取当前文章cid
+            const cidInput = document.querySelector('input[name=cid]');
+            const cid = cidInput ? cidInput.value : null;
+            
+            // 加入队列
+            uploadQueue.push({ file, cid });
+            if (uploadQueue.length === 1) {
+                processQueue();
+            }
+        };
+        
+        function showUploadError(type, file) {
+            let word = '上传出现错误';
+            switch (type) {
+                case 'size': word = '文件大小超过限制'; break;
+                case 'type': word = '文件扩展名不被支持'; break;
+            }
+            
+            const fileList = document.getElementById('file-list');
+            const li = document.createElement('li');
+            li.innerHTML = file.name + ' 上传失败<br />' + word;
+            li.style.backgroundColor = '#FBC2C4';
+            fileList.appendChild(li);
+            setTimeout(() => li.remove(), 3000);
+        }
+        
+        // 接管页面上已有附件的删除事件
+        document.querySelectorAll('#file-list li').forEach(function(li) {
+            attachS3Events(li);
+        });
+        
+        console.log('S3 Direct Upload 已启用');
+    })();
+});
+</script>
+SCRIPT;
     }
 
     /**

--- a/S3Client.php
+++ b/S3Client.php
@@ -45,20 +45,15 @@ class S3Upload_S3Client
     public function putObject($path, $file)
     {
         S3Upload_Utils::log("S3Client::putObject 开始 - 路径: {$path}", 'debug');
-
+        
         $date = gmdate('Ymd\THis\Z');
         $shortDate = substr($date, 0, 8);
 
-        $payload = file_get_contents($file);
-        if ($payload === false) {
-            S3Upload_Utils::log("无法读取文件: {$file}", 'error');
-            throw new Exception('无法读取文件');
-        }
-
-        S3Upload_Utils::log("文件读取成功，大小: " . strlen($payload) . " bytes", 'debug');
+        $fileHandle = fopen($file, 'rb');
+        $fileSize = filesize($file);
 
         $contentType = S3Upload_Utils::getMimeType($file);
-        $contentSha256 = hash('sha256', $payload);
+        $contentSha256 = hash_file('sha256', $file);
 
         // 准备请求
         $canonical_uri = '/' . $this->bucket . '/' . ltrim($path, '/');
@@ -68,9 +63,9 @@ class S3Upload_S3Client
 
         // 准备请求头
         $headers = array(
-            'content-length' => strlen($payload),
+            'content-length' => $fileSize,
             'content-type' => $contentType,
-            'host' => $this->endpoint,
+            'host' => $this->options->customDomain,
             'x-amz-content-sha256' => $contentSha256,
             'x-amz-date' => $date
         );
@@ -87,7 +82,7 @@ class S3Upload_S3Client
 
         // 准备 cURL 请求
         $ch = curl_init();
-        $url = 'https://' . $this->endpoint . $canonical_uri;
+        $url = 'http://' . $this->endpoint . $canonical_uri;
 
         S3Upload_Utils::log("上传URL: {$url}", 'debug');
 
@@ -105,17 +100,20 @@ class S3Upload_S3Client
             CURLOPT_URL => $url,
             CURLOPT_HTTPHEADER => $curlHeaders,
             CURLOPT_CUSTOMREQUEST => 'PUT',
-            CURLOPT_POSTFIELDS => $payload,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => $sslVerify,
             CURLOPT_SSL_VERIFYHOST => $sslVerify ? 2 : 0,
-            CURLOPT_HEADER => true
+            CURLOPT_HEADER => true,
+            CURLOPT_UPLOAD => true,       // 明确这是一个上传
+            CURLOPT_INFILE => $fileHandle, // 告诉cURL从这个文件句柄读取数据
+            CURLOPT_INFILESIZE => $fileSize // 告诉cURL要上传的总字节数
         ));
 
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $curlError = curl_error($ch);
         curl_close($ch);
+        fclose($fileHandle);
 
         S3Upload_Utils::log("HTTP响应码: {$httpCode}", 'debug');
 
@@ -142,14 +140,19 @@ class S3Upload_S3Client
      */
     public function deleteObject($path)
     {
+        S3Upload_Utils::log("S3Client::deleteObject 开始 - 路径: {$path}", 'debug');
+        
         $date = gmdate('Ymd\THis\Z');
         $shortDate = substr($date, 0, 8);
         
         $canonical_uri = '/' . $this->bucket . '/' . ltrim($path, '/');
         $canonical_querystring = '';
         
+        // 使用 endpoint 作为 host（和 putObject 保持一致）
+        $host = $this->endpoint;
+        
         $headers = array(
-            'host' => $this->endpoint,
+            'host' => $host,
             'x-amz-content-sha256' => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
             'x-amz-date' => $date
         );
@@ -164,7 +167,10 @@ class S3Upload_S3Client
         );
         
         $ch = curl_init();
-        $url = 'https://' . $this->endpoint . $canonical_uri;
+        $protocol = $this->options->useHttps === 'true' ? 'https://' : 'http://';
+        $url = $protocol . $this->endpoint . $canonical_uri;
+        
+        S3Upload_Utils::log("删除URL: {$url}", 'debug');
         
         $curlHeaders = array();
         foreach ($headers as $key => $value) {
@@ -181,14 +187,32 @@ class S3Upload_S3Client
             CURLOPT_CUSTOMREQUEST => 'DELETE',
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => $sslVerify,
-            CURLOPT_SSL_VERIFYHOST => $sslVerify ? 2 : 0
+            CURLOPT_SSL_VERIFYHOST => $sslVerify ? 2 : 0,
+            CURLOPT_HEADER => true
         ));
         
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
         curl_close($ch);
         
-        return $httpCode === 204 || $httpCode === 200;
+        S3Upload_Utils::log("删除响应码: {$httpCode}", 'debug');
+        
+        if ($curlError) {
+            S3Upload_Utils::log("删除cURL错误: {$curlError}", 'error');
+            return false;
+        }
+        
+        // S3 删除成功返回 204，有些兼容S3的服务可能返回 200
+        $success = $httpCode === 204 || $httpCode === 200;
+        
+        if (!$success) {
+            S3Upload_Utils::log("删除失败，HTTP状态码: {$httpCode}，响应: {$response}", 'error');
+        } else {
+            S3Upload_Utils::log("删除成功", 'debug');
+        }
+        
+        return $success;
     }
 
     /**
@@ -255,26 +279,19 @@ class S3Upload_S3Client
         if (!empty($this->options->customDomain)) {
             $domain = rtrim($this->options->customDomain, '/');
             
-            // 构建完整路径
-            if (!empty($customPath)) {
-                return $protocol . $domain . '/' . $customPath . '/' . $path;
+            if ($this->options->urlStyle === 'virtual') { 
+                return $protocol . $domain . '/' . $path;
             }
-            
-            return $protocol . $domain . '/' . $path;
+            else {
+                return $protocol . $domain . '/' . $this->bucket . '/' . $path;
+            }
         }
 
         // 没有自定义域名时，根据URL风格生成地址
         if ($this->options->urlStyle === 'virtual') {
-            if (!empty($customPath)) {
-                return $protocol . $this->bucket . '.' . $this->endpoint . '/' . $customPath . '/' . $path;
-            }
             return $protocol . $this->bucket . '.' . $this->endpoint . '/' . $path;
         }
 
-        // 路径形式
-        if (!empty($customPath)) {
-            return $protocol . $this->endpoint . '/' . $this->bucket . '/' . $customPath . '/' . $path;
-        }
         return $protocol . $this->endpoint . '/' . $this->bucket . '/' . $path;
     }
 
@@ -294,5 +311,111 @@ class S3Upload_S3Client
 
         // 合并路径
         return $path . '/' . $fileName;
+    }
+
+    /**
+     * 生成预签名上传URL (用于浏览器直传S3)
+     * 
+     * @param string $path 对象路径
+     * @param string $contentType MIME类型
+     * @param int $expires 过期时间(秒)，默认3600秒
+     * @return array 包含上传URL和相关信息
+     */
+    public function getPresignedUploadUrl($path, $contentType = 'application/octet-stream', $expires = 3600)
+    {
+        $date = gmdate('Ymd\THis\Z');
+        $shortDate = substr($date, 0, 8);
+        $expireTime = time() + $expires;
+        
+        $service = 's3';
+        $algorithm = 'AWS4-HMAC-SHA256';
+        $credential_scope = $shortDate . '/' . $this->region . '/' . $service . '/aws4_request';
+        
+        // 构建canonical URI
+        $canonical_uri = '/' . $this->bucket . '/' . ltrim($path, '/');
+        
+        // 构建查询字符串参数
+        $params = [
+            'X-Amz-Algorithm' => $algorithm,
+            'X-Amz-Credential' => $this->accessKey . '/' . $credential_scope,
+            'X-Amz-Date' => $date,
+            'X-Amz-Expires' => $expires,
+            'X-Amz-SignedHeaders' => 'content-type;host'
+        ];
+        
+        // 按字母顺序排序
+        ksort($params);
+        $canonical_querystring = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        
+        // 使用 endpoint 作为 host
+        $host = $this->endpoint;
+        
+        // Canonical headers
+        $canonical_headers = "content-type:" . $contentType . "\n" . "host:" . $host . "\n";
+        $signed_headers = 'content-type;host';
+        
+        // 对于预签名URL，payload是UNSIGNED-PAYLOAD
+        $payload_hash = 'UNSIGNED-PAYLOAD';
+        
+        // Canonical Request
+        $canonical_request = "PUT\n"
+            . $canonical_uri . "\n"
+            . $canonical_querystring . "\n"
+            . $canonical_headers . "\n"
+            . $signed_headers . "\n"
+            . $payload_hash;
+        
+        // String to Sign
+        $string_to_sign = $algorithm . "\n"
+            . $date . "\n"
+            . $credential_scope . "\n"
+            . hash('sha256', $canonical_request);
+        
+        // Signing Key
+        $kSecret = 'AWS4' . $this->secretKey;
+        $kDate = hash_hmac('sha256', $shortDate, $kSecret, true);
+        $kRegion = hash_hmac('sha256', $this->region, $kDate, true);
+        $kService = hash_hmac('sha256', $service, $kRegion, true);
+        $kSigning = hash_hmac('sha256', 'aws4_request', $kService, true);
+        $signature = hash_hmac('sha256', $string_to_sign, $kSigning);
+        
+        // 构建最终URL
+        $protocol = $this->options->useHttps === 'true' ? 'https://' : 'http://';
+        $presignedUrl = $protocol . $host . $canonical_uri . '?' . $canonical_querystring . '&X-Amz-Signature=' . $signature;
+        
+        return [
+            'uploadUrl' => $presignedUrl,
+            'path' => $path,
+            'contentType' => $contentType,
+            'expires' => $expireTime,
+            'objectUrl' => $this->getObjectUrl($path)
+        ];
+    }
+
+    /**
+     * 根据文件名生成完整的存储路径（包含自定义前缀）
+     * 
+     * @param string $filename 文件名
+     * @return string 完整路径
+     */
+    public function generateFullPath($filename)
+    {
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $ext = $ext ? strtolower($ext) : '';
+
+        $date = new \Typecho\Date();
+        $basePath = $date->year . '/' . $date->month;
+
+        // 生成文件名
+        $newFileName = sprintf('%u', crc32(uniqid())) . ($ext ? '.' . $ext : '');
+        $path = $basePath . '/' . $newFileName;
+
+        // 添加自定义路径前缀
+        if (!empty($this->options->customPath)) {
+            $customPath = trim($this->options->customPath, '/');
+            $path = $customPath . '/' . $path;
+        }
+
+        return $path;
     }
 }

--- a/StreamUploader.php
+++ b/StreamUploader.php
@@ -62,7 +62,7 @@ class S3Upload_StreamUploader
             }
 
             // 使用S3Client获取正确的URL
-            $url = $this->s3Client->getObjectUrl($path);
+            $url = $this->s3Client->getObjectUrl($fullPath);
 
             // 获取文件扩展名和MIME类型
             $extension = $this->getFileExt($file['name']);
@@ -72,7 +72,7 @@ class S3Upload_StreamUploader
 
             return array(
                 'name' => $file['name'],
-                'path' => $path,
+                'path' => $fullPath,
                 'size' => $file['size'],
                 'type' => $extension,
                 'mime' => $mimeType,

--- a/Utils.php
+++ b/Utils.php
@@ -20,7 +20,7 @@ class S3Upload_Utils
     {
         $date = date('Y-m-d H:i:s');
         $logMessage = "[{$date}] [{$level}] {$message}\n";
-        
+
         $logDir = __TYPECHO_ROOT_DIR__ . '/usr/logs';
         if (!is_dir($logDir)) {
             mkdir($logDir, 0755, true);


### PR DESCRIPTION
我得承认这些全都是claude和gemini帮我写的，我就只在自己的服务器上（Typecho 1.3.0 + RustFS作为S3服务器）测试了一下，效果还不错

S3直传是通过注册插件的时候向页面注入js代码实现的，注入的js代码中列举的文件类型是读取系统设置得到的。我其实没太搞得懂S3 Endpoint和自定义域名这两个都负责什么……总之我测试时使用的配置中，这两者是一致的，这样测试可以正常工作。

文件读取方式优化指的是php转发文件的时候不再一次性读入内存，而是使用常见的文件上传机制。不过S3直传的话就无所谓了。

抱歉我是真不会写php，这些代码基本就是仅供参考，希望作者大大审核